### PR TITLE
fix: do not trigger drag operation with right mouse button

### DIFF
--- a/lib/src/mixins/DragMixin.ts
+++ b/lib/src/mixins/DragMixin.ts
@@ -90,7 +90,7 @@ export default class DragMixin extends DragAwareMixin {
         }
 
         function onMouseDown(e) {
-            if (!comp.disabled && downEvent === null) {
+            if (!comp.disabled && downEvent === null && e.buttons === 1) {
                 initialUserSelect = document.body.style.userSelect;
                 document.documentElement.style.userSelect = 'none'; // Permet au drag de se poursuivre normalement même
                 // quand on quitte un élémént avec overflow: hidden.


### PR DESCRIPTION
when user right clicks on an item (ie. to open the browser contextual menu), this shouldnt be considered as a drag start operation

The screen capture below shows the bug on Firefox
![right click issue](https://user-images.githubusercontent.com/1901769/124927341-d1d4bf00-dffe-11eb-9abb-711ab5846a7b.gif)

reproduced on MacOS Big Sur (11.4 / Apple Silicon) 
- Chrome 91.0.4472.114
- Safari 14.1.1
- Firefox 89.0.2

