### PR TITLE
Scrolling improvements + tap vibration feedback on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Yes with a polyfill for custom events such as https://www.npmjs.com/package/cust
 
 ## Does it support touch devices ?
 
-Yes.
+Yes, including tap `vibration` prop on Drag component.
 
 ## Does it support SSR ?
 

--- a/README.md
+++ b/README.md
@@ -183,14 +183,15 @@ Comparing to the Drop component, there are two more events :
 * `insert` : emitted when the user drops data into the DropList. If no listener is provided for this event, the list cannot be inserted into.
 * `reorder` : emitted when the user reorders the list. If no listener is provided for this event, the list cannot be reordered.
 
-Comparing to the Drop component, there are five more slots :
+Comparing to the Drop component, there are six more slots :
 * `item` : used to render each list item. It has three properties, `item` , `index` and `reorder`. Reorder is true when the item is the one subject to reordering. **Don't forget to provide a key for the content of this slot !!**
 * `feedback` : used to render a placeholder to show the position where the new item would be inserted if the drag operation ended at the current mouse position. It has two properties : `type` and `data`. **Don't forget to provide a key for the content of this slot !!** 
 * `reordering-drag-image` : defines the drag image to be used when reordering the list (see drag image section above).
 * `reordering-feedback` : used to control the feedback used during reordering
   * if this slot isn't defined, then the items switch positions during reordering to display in real time the order that will be achieved if the drag terminates at the current position
   * if this slot is defined, then its content is inserted into the list to display the new location of the item being dragged (for an example of this, see nested drop lists)
-* `empty` : defined content to display if the list is empty and not being dragged into
+* `empty` : defined content to display if the list is empty and not being dragged into. (To alter the outer div for the empty slot, use `default-slot-class` prop)
+* `default` : default content to add at the end of the DropList. (To alter the outer div for the default slot, use `default-slot-class` prop)
 
 Keys on items and feedback are used to disallow the drop if it would create duplicates and result in errors.
 
@@ -244,6 +245,8 @@ The `disabled` prop can be used to temporarily disable drag on Drag components.
 On Drag and Drop components, the `drag-image-opacity` prop can be used to control the opacity of the drag image.
 
 On Drag components, if the `go-back` prop is set to true, then if a drag is not successful, the drag image will go back to where the drag originated.
+
+Drag components also have the option for a `vibration` prop which will add feedback on supported mobile devices.
 
 https://codesandbox.io/s/example-1-l6p54
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -183,14 +183,15 @@ Comparing to the Drop component, there are two more events :
 * `insert` : emitted when the user drops data into the DropList. If no listener is provided for this event, the list cannot be inserted into.
 * `reorder` : emitted when the user reorders the list. If no listener is provided for this event, the list cannot be reordered.
 
-Comparing to the Drop component, there are five more slots :
+Comparing to the Drop component, there are six more slots :
 * `item` : used to render each list item. It has three properties, `item` , `index` and `reorder`. Reorder is true when the item is the one subject to reordering. **Don't forget to provide a key for the content of this slot !!**
 * `feedback` : used to render a placeholder to show the position where the new item would be inserted if the drag operation ended at the current mouse position. It has two properties : `type` and `data`. **Don't forget to provide a key for the content of this slot !!** 
 * `reordering-drag-image` : defines the drag image to be used when reordering the list (see drag image section above).
 * `reordering-feedback` : used to control the feedback used during reordering
   * if this slot isn't defined, then the items switch positions during reordering to display in real time the order that will be achieved if the drag terminates at the current position
   * if this slot is defined, then its content is inserted into the list to display the new location of the item being dragged (for an example of this, see nested drop lists)
-* `empty` : defined content to display if the list is empty and not being dragged into
+* `empty` : defined content to display if the list is empty and not being dragged into. (To alter the outer div for the empty slot, use `default-slot-class` prop)
+* `default` : default content to add at the end of the DropList. (To alter the outer div for the default slot, use `default-slot-class` prop)
 
 Keys on items and feedback are used to disallow the drop if it would create duplicates and result in errors.
 
@@ -245,6 +246,8 @@ On Drag and Drop components, the `drag-image-opacity` prop can be used to contro
 
 On Drag components, if the `go-back` prop is set to true, then if a drag is not successful, the drag image will go back to where the drag originated.
 
+Drag components also have the option for a `vibration` prop which will add feedback on supported mobile devices.
+
 https://codesandbox.io/s/example-1-l6p54
 
 ![demo](img/vid12.gif)
@@ -257,7 +260,7 @@ Yes with a polyfill for custom events such as https://www.npmjs.com/package/cust
 
 ## Does it support touch devices ?
 
-Yes.
+Yes, including tap `vibration` prop on Drag component.
 
 ## Does it support SSR ?
 

--- a/lib/dist/components/DropList.vue.d.ts
+++ b/lib/dist/components/DropList.vue.d.ts
@@ -7,6 +7,7 @@ export default class DropList extends DropMixin {
     row: boolean;
     column: boolean;
     noAnimations: boolean;
+    defaultSlotClass: any;
     grid: Grid;
     forbiddenKeys: any[];
     feedbackKey: any;

--- a/lib/dist/mixins/DragMixin.d.ts
+++ b/lib/dist/mixins/DragMixin.d.ts
@@ -10,6 +10,7 @@ export default class DragMixin extends DragAwareMixin {
     delta: number;
     delay: number;
     dragClass: String;
+    vibration: number;
     mouseIn: boolean;
     created(): void;
     reEmit(eventName: string): void;

--- a/lib/dist/vue-easy-dnd.esm.js
+++ b/lib/dist/vue-easy-dnd.esm.js
@@ -298,6 +298,201 @@ function copyStyle(src, destination) {
     destination.style.pointerEvents = 'none';
 }
 
+// Forked from https://gist.github.com/gre/296291b8ce0d8fe6e1c3ea4f1d1c5c3b
+var regex = /(auto|scroll)/;
+
+var style = function (node, prop) { return getComputedStyle(node, null).getPropertyValue(prop); };
+
+var scroll = function (node) { return regex.test(
+    style(node, "overflow") +
+    style(node, "overflow-y") +
+    style(node, "overflow-x")); };
+
+var scrollparent = function (node) { return !node || node===document.body
+    ? document.body
+    : scroll(node)
+      ? node
+      : scrollparent(node.parentNode); };
+
+// Forked from https://github.com/bennadel/JavaScript-Demos/blob/master/demos/window-edge-scrolling/index.htm
+// Code was altered to work with scrollable containers
+
+var edgeSize = 100;
+var timer = null;
+
+function cancelScrollAction () {
+  clearTimeout(timer);
+}
+
+function performEdgeScroll(event, container, clientX, clientY) {
+  if (!container) {
+    return false;
+  }
+  
+  // NOTE: Much of the information here, with regard to document dimensions,
+  // viewport dimensions, and window scrolling is derived from JavaScript.info.
+  // I am consuming it here primarily as NOTE TO SELF.
+  // --
+  // Read More: https://javascript.info/size-and-scroll-window
+  // --
+  // CAUTION: The viewport and document dimensions can all be CACHED and then
+  // recalculated on window-resize events (for the most part). I am keeping it
+  // all here in the mousemove event handler to remove as many of the moving
+  // parts as possible and keep the demo as simple as possible.
+  
+  // Get the viewport-relative coordinates of the mousemove event.
+  var rect = container.getBoundingClientRect();
+  var isBody = container === document.body;
+  
+  var viewportX = clientX - rect.left;
+  var viewportY = clientY - rect.top;
+  if (isBody) {
+    viewportX = clientX;
+    viewportY = clientY;
+  }
+  
+  // Get the viewport dimensions.
+  var viewportWidth = rect.width;
+  var viewportHeight = rect.height;
+  
+  // Next, we need to determine if the mouse is within the "edge" of the
+  // viewport, which may require scrolling the window. To do this, we need to
+  // calculate the boundaries of the edge in the viewport (these coordinates
+  // are relative to the viewport grid system).
+  var edgeTop = edgeSize;
+  var edgeLeft = edgeSize;
+  var edgeBottom = ( viewportHeight - edgeSize );
+  var edgeRight = ( viewportWidth - edgeSize );
+  
+  var isInLeftEdge = ( viewportX < edgeLeft );
+  var isInRightEdge = ( viewportX > edgeRight );
+  var isInTopEdge = ( viewportY < edgeTop );
+  var isInBottomEdge = ( viewportY > edgeBottom );
+  
+  // If the mouse is not in the viewport edge, there's no need to calculate
+  // anything else.
+  if (!(isInLeftEdge || isInRightEdge || isInTopEdge || isInBottomEdge)) {
+    cancelScrollAction();
+    return false;
+  }
+  
+  // If we made it this far, the user's mouse is located within the edge of the
+  // viewport. As such, we need to check to see if scrolling needs to be done.
+  
+  // Get the document dimensions.
+  // --
+  // NOTE: The various property reads here are for cross-browser compatibility
+  // as outlined in the JavaScript.info site (link provided above).
+  var documentWidth = Math.max(
+    container.scrollWidth,
+    container.offsetWidth,
+    container.clientWidth
+  );
+  var documentHeight = Math.max(
+    container.scrollHeight,
+    container.offsetHeight,
+    container.clientHeight
+  );
+  
+  // Calculate the maximum scroll offset in each direction. Since you can only
+  // scroll the overflow portion of the document, the maximum represents the
+  // length of the document that is NOT in the viewport.
+  var maxScrollX = (documentWidth - viewportWidth);
+  var maxScrollY = (documentHeight - viewportHeight);
+  
+  // As we examine the mousemove event, we want to adjust the window scroll in
+  // immediate response to the event; but, we also want to continue adjusting
+  // the window scroll if the user rests their mouse in the edge boundary. To
+  // do this, we'll invoke the adjustment logic immediately. Then, we'll setup
+  // a timer that continues to invoke the adjustment logic while the window can
+  // still be scrolled in a particular direction.
+  // --
+  // NOTE: There are probably better ways to handle the ongoing animation
+  // check. But, the point of this demo is really about the math logic, not so
+  // much about the interval logic.
+  (function checkForWindowScroll() {
+    cancelScrollAction();
+    
+    if (adjustWindowScroll()) {
+      timer = setTimeout( checkForWindowScroll, 30 );
+    }
+  })();
+  
+  // Adjust the window scroll based on the user's mouse position. Returns True
+  // or False depending on whether or not the window scroll was changed.
+  function adjustWindowScroll() {
+    // Get the current scroll position of the document.
+    var currentScrollX = container.scrollLeft;
+    var currentScrollY = container.scrollTop;
+    if (isBody) {
+      currentScrollX = window.pageXOffset;
+      currentScrollY = window.pageYOffset;
+    }
+    
+    // Determine if the window can be scrolled in any particular direction.
+    var canScrollUp = (currentScrollY > 0);
+    var canScrollDown = (currentScrollY < maxScrollY);
+    var canScrollLeft = (currentScrollX > 0);
+    var canScrollRight = (currentScrollX < maxScrollX);
+    
+    // Since we can potentially scroll in two directions at the same time,
+    // let's keep track of the next scroll, starting with the current scroll.
+    // Each of these values can then be adjusted independently in the logic
+    // below.
+    var nextScrollX = currentScrollX;
+    var nextScrollY = currentScrollY;
+    
+    // As we examine the mouse position within the edge, we want to make the
+    // incremental scroll changes more "intense" the closer that the user
+    // gets the viewport edge. As such, we'll calculate the percentage that
+    // the user has made it "through the edge" when calculating the delta.
+    // Then, that use that percentage to back-off from the "max" step value.
+    var maxStep = 50;
+    
+    // Should we scroll left?
+    if (isInLeftEdge && canScrollLeft) {
+      var intensity = ((edgeLeft - viewportX) / edgeSize);
+      nextScrollX = (nextScrollX - (maxStep * intensity));
+    }
+    // Should we scroll right?
+    else if (isInRightEdge && canScrollRight) {
+      var intensity = ((viewportX - edgeRight) / edgeSize);
+      nextScrollX = (nextScrollX + (maxStep * intensity));
+    }
+    
+    // Should we scroll up?
+    if (isInTopEdge && canScrollUp) {
+      var intensity = ((edgeTop - viewportY) / edgeSize);
+      nextScrollY = (nextScrollY - (maxStep * intensity));
+    }
+    // Should we scroll down?
+    else if (isInBottomEdge && canScrollDown) {
+      var intensity = ((viewportY - edgeBottom) / edgeSize);
+      nextScrollY = (nextScrollY + (maxStep * intensity));
+    }
+    
+    // Sanitize invalid maximums. An invalid scroll offset won't break the
+    // subsequent .scrollTo() call; however, it will make it harder to
+    // determine if the .scrollTo() method should have been called in the
+    // first place.
+    nextScrollX = Math.max(0, Math.min(maxScrollX, nextScrollX));
+    nextScrollY = Math.max(0, Math.min(maxScrollY, nextScrollY));
+    
+    if (
+      (nextScrollX !== currentScrollX) ||
+      (nextScrollY !== currentScrollY)
+    ) {
+      (isBody ? window : container).scrollTo(nextScrollX, nextScrollY);
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+  
+  return true
+}
+
 var DragMixin = /** @class */ (function (_super) {
     __extends(DragMixin, _super);
     function DragMixin() {
@@ -327,6 +522,7 @@ var DragMixin = /** @class */ (function (_super) {
         var downEvent = null;
         var startPosition = null;
         var delayTimer = null;
+        var scrollContainer = null;
         var hasPassedDelay = true;
         el.addEventListener('mousedown', onMouseDown);
         el.addEventListener('touchstart', onMouseDown);
@@ -341,6 +537,12 @@ var DragMixin = /** @class */ (function (_super) {
         function noop(e) {
             e.stopPropagation();
             e.preventDefault();
+        }
+        function performVibration() {
+            // If browser can perform vibration and user has defined a vibration, perform it
+            if (comp.vibration > 0 && window.navigator && window.navigator.vibrate) {
+                window.navigator.vibrate(comp.vibration);
+            }
         }
         function onMouseDown(e) {
             var target;
@@ -357,6 +559,7 @@ var DragMixin = /** @class */ (function (_super) {
             }
             var goodTarget = !comp.handle || target.matches(comp.handle + ', ' + comp.handle + ' *');
             if (!comp.disabled && downEvent === null && goodButton && goodTarget) {
+                scrollContainer = scrollparent(target);
                 initialUserSelect = document.body.style.userSelect;
                 document.documentElement.style.userSelect = 'none'; // Permet au drag de se poursuivre normalement même
                 // quand on quitte un élémént avec overflow: hidden.
@@ -381,7 +584,11 @@ var DragMixin = /** @class */ (function (_super) {
                     clearTimeout(delayTimer);
                     delayTimer = setTimeout(function () {
                         hasPassedDelay = true;
+                        performVibration();
                     }, comp.delay);
+                }
+                else {
+                    performVibration();
                 }
                 document.addEventListener('click', onMouseClick, true);
                 document.addEventListener('mousemove', onMouseMove);
@@ -452,6 +659,9 @@ var DragMixin = /** @class */ (function (_super) {
             }
             // Dispatch custom easy-dnd-move event :
             if (dragStarted) {
+                // If cursor is at edge of container, perform scroll if available
+                // If comp.dragTop is defined, it means they are dragging on top of another DropList/EasyDnd component
+                performEdgeScroll(e, comp.dragTop ? scrollparent(comp.dragTop.$el) : scrollContainer, x, y);
                 var custom = new CustomEvent("easy-dnd-move", {
                     bubbles: true,
                     cancelable: true,
@@ -474,10 +684,12 @@ var DragMixin = /** @class */ (function (_super) {
         function onMouseUp(e) {
             hasPassedDelay = true;
             clearTimeout(delayTimer);
+            cancelScrollAction();
             // On touch devices, we ignore fake mouse events and deal with touch events only.
             if (downEvent.type === 'touchstart' && e.type === 'mouseup')
                 { return; }
             downEvent = null;
+            scrollContainer = null;
             // This delay makes sure that when the click event that results from the mouseup is produced, the drag is
             // still in progress. So by checking the flag dnd.inProgress, one can tell apart true clicks from drag and
             // drop artefacts.
@@ -597,6 +809,10 @@ var DragMixin = /** @class */ (function (_super) {
         Prop({ type: String, default: null }),
         __metadata("design:type", String)
     ], DragMixin.prototype, "dragClass", void 0);
+    __decorate([
+        Prop({ type: Number, default: 0 }),
+        __metadata("design:type", Number)
+    ], DragMixin.prototype, "vibration", void 0);
     DragMixin = __decorate([
         Component({})
     ], DragMixin);
@@ -1751,6 +1967,10 @@ var DropList = /** @class */ (function (_super) {
         Prop({ default: false, type: Boolean }),
         __metadata("design:type", Boolean)
     ], DropList.prototype, "noAnimations", void 0);
+    __decorate([
+        Prop({ default: null, type: [String, Object] }),
+        __metadata("design:type", Object)
+    ], DropList.prototype, "defaultSlotClass", void 0);
     DropList = __decorate([
         Component({
             components: { DragFeedback: DragFeedback$1 },
@@ -1764,18 +1984,18 @@ var DropList = /** @class */ (function (_super) {
 var __vue_script__$4 = DropList;
 
 /* template */
-var __vue_render__$4 = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c(_vm.rootTag,_vm._g(_vm._b({tag:"component",class:_vm.clazz,style:(_vm.style)},'component',_vm.rootProps,false),_vm.rootListeners),[(_vm.dropIn && _vm.dropAllowed)?[(_vm.reordering)?[(_vm.hasReorderingFeedback)?[_vm._l((_vm.itemsBeforeReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":index})}),_vm._v(" "),_vm._t("reordering-feedback",null,{"item":_vm.items[_vm.fromIndex]}),_vm._v(" "),_vm._l((_vm.itemsAfterReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":_vm.itemsBeforeReorderingFeedback.length + index})})]:[_vm._l((_vm.reorderedItems),function(item,index){return _vm._t("item",null,{"item":item,"index":index,"reorder":index === _vm.closestIndex})})]]:[_vm._l((_vm.itemsBeforeFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType}),_vm._v(" "),_vm._l((_vm.itemsAfterFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":_vm.itemsBeforeFeedback.length + index})})]]:[_vm._l((_vm.items),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),(_vm.items.length < 1)?_c('div',{key:"empty"},[_vm._t("empty")],2):_vm._e()],_vm._v(" "),(_vm.showDragFeedback)?_c('drag-feedback',{key:"drag-feedback",ref:"feedback",staticClass:"__feedback"},[_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType})],2):_vm._e(),_vm._v(" "),(_vm.showInsertingDragImage)?_c('div',{key:"inserting-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("drag-image",null,{"type":_vm.dragType,"data":_vm.dragData})],2):_vm._e(),_vm._v(" "),(_vm.showReorderingDragImage)?_c('div',{key:"reordering-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("reordering-drag-image",null,{"item":_vm.items[_vm.fromIndex]})],2):_vm._e(),_vm._v(" "),_c('div',{key:"drop-list-content"},[_vm._t("default")],2)],2)};
+var __vue_render__$4 = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c(_vm.rootTag,_vm._g(_vm._b({tag:"component",class:_vm.clazz,style:(_vm.style)},'component',_vm.rootProps,false),_vm.rootListeners),[(_vm.dropIn && _vm.dropAllowed)?[(_vm.reordering)?[(_vm.hasReorderingFeedback)?[_vm._l((_vm.itemsBeforeReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":index})}),_vm._v(" "),_vm._t("reordering-feedback",null,{"item":_vm.items[_vm.fromIndex]}),_vm._v(" "),_vm._l((_vm.itemsAfterReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":_vm.itemsBeforeReorderingFeedback.length + index})})]:[_vm._l((_vm.reorderedItems),function(item,index){return _vm._t("item",null,{"item":item,"index":index,"reorder":index === _vm.closestIndex})})]]:[_vm._l((_vm.itemsBeforeFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType}),_vm._v(" "),_vm._l((_vm.itemsAfterFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":_vm.itemsBeforeFeedback.length + index})})]]:[_vm._l((_vm.items),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),(_vm.items.length < 1)?_c('div',{key:"empty",class:_vm.defaultSlotClass},[_vm._t("empty")],2):_vm._e()],_vm._v(" "),(_vm.showDragFeedback)?_c('drag-feedback',{key:"drag-feedback",ref:"feedback",staticClass:"__feedback"},[_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType})],2):_vm._e(),_vm._v(" "),(_vm.showInsertingDragImage)?_c('div',{key:"inserting-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("drag-image",null,{"type":_vm.dragType,"data":_vm.dragData})],2):_vm._e(),_vm._v(" "),(_vm.showReorderingDragImage)?_c('div',{key:"reordering-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("reordering-drag-image",null,{"item":_vm.items[_vm.fromIndex]})],2):_vm._e(),_vm._v(" "),_c('div',{key:"drop-list-content",class:_vm.defaultSlotClass},[_vm._t("default")],2)],2)};
 var __vue_staticRenderFns__$4 = [];
 
   /* style */
   var __vue_inject_styles__$4 = function (inject) {
     if (!inject) { return }
-    inject("data-v-b1058386_0", { source: ".drop-list[data-v-b1058386]>*{transition:transform .2s}.__feedback[data-v-b1058386]{display:none}.__drag-image[data-v-b1058386]{position:fixed;top:-10000px;left:-10000px;will-change:left,top}", map: undefined, media: undefined })
-,inject("data-v-b1058386_1", { source: ".drop-allowed.drop-in *{cursor:inherit!important}.drop-forbidden.drop-in,.drop-forbidden.drop-in *{cursor:no-drop!important}", map: undefined, media: undefined });
+    inject("data-v-0c0d6738_0", { source: ".drop-list[data-v-0c0d6738]>*{transition:transform .2s}.__feedback[data-v-0c0d6738]{display:none}.__drag-image[data-v-0c0d6738]{position:fixed;top:-10000px;left:-10000px;will-change:left,top}", map: undefined, media: undefined })
+,inject("data-v-0c0d6738_1", { source: ".drop-allowed.drop-in *{cursor:inherit!important}.drop-forbidden.drop-in,.drop-forbidden.drop-in *{cursor:no-drop!important}", map: undefined, media: undefined });
 
   };
   /* scoped */
-  var __vue_scope_id__$4 = "data-v-b1058386";
+  var __vue_scope_id__$4 = "data-v-0c0d6738";
   /* module identifier */
   var __vue_module_identifier__$4 = undefined;
   /* functional template */

--- a/lib/dist/vue-easy-dnd.js
+++ b/lib/dist/vue-easy-dnd.js
@@ -298,6 +298,201 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
         destination.style.pointerEvents = 'none';
     }
 
+    // Forked from https://gist.github.com/gre/296291b8ce0d8fe6e1c3ea4f1d1c5c3b
+    var regex = /(auto|scroll)/;
+
+    var style = function (node, prop) { return getComputedStyle(node, null).getPropertyValue(prop); };
+
+    var scroll = function (node) { return regex.test(
+        style(node, "overflow") +
+        style(node, "overflow-y") +
+        style(node, "overflow-x")); };
+
+    var scrollparent = function (node) { return !node || node===document.body
+        ? document.body
+        : scroll(node)
+          ? node
+          : scrollparent(node.parentNode); };
+
+    // Forked from https://github.com/bennadel/JavaScript-Demos/blob/master/demos/window-edge-scrolling/index.htm
+    // Code was altered to work with scrollable containers
+
+    var edgeSize = 100;
+    var timer = null;
+
+    function cancelScrollAction () {
+      clearTimeout(timer);
+    }
+
+    function performEdgeScroll(event, container, clientX, clientY) {
+      if (!container) {
+        return false;
+      }
+      
+      // NOTE: Much of the information here, with regard to document dimensions,
+      // viewport dimensions, and window scrolling is derived from JavaScript.info.
+      // I am consuming it here primarily as NOTE TO SELF.
+      // --
+      // Read More: https://javascript.info/size-and-scroll-window
+      // --
+      // CAUTION: The viewport and document dimensions can all be CACHED and then
+      // recalculated on window-resize events (for the most part). I am keeping it
+      // all here in the mousemove event handler to remove as many of the moving
+      // parts as possible and keep the demo as simple as possible.
+      
+      // Get the viewport-relative coordinates of the mousemove event.
+      var rect = container.getBoundingClientRect();
+      var isBody = container === document.body;
+      
+      var viewportX = clientX - rect.left;
+      var viewportY = clientY - rect.top;
+      if (isBody) {
+        viewportX = clientX;
+        viewportY = clientY;
+      }
+      
+      // Get the viewport dimensions.
+      var viewportWidth = rect.width;
+      var viewportHeight = rect.height;
+      
+      // Next, we need to determine if the mouse is within the "edge" of the
+      // viewport, which may require scrolling the window. To do this, we need to
+      // calculate the boundaries of the edge in the viewport (these coordinates
+      // are relative to the viewport grid system).
+      var edgeTop = edgeSize;
+      var edgeLeft = edgeSize;
+      var edgeBottom = ( viewportHeight - edgeSize );
+      var edgeRight = ( viewportWidth - edgeSize );
+      
+      var isInLeftEdge = ( viewportX < edgeLeft );
+      var isInRightEdge = ( viewportX > edgeRight );
+      var isInTopEdge = ( viewportY < edgeTop );
+      var isInBottomEdge = ( viewportY > edgeBottom );
+      
+      // If the mouse is not in the viewport edge, there's no need to calculate
+      // anything else.
+      if (!(isInLeftEdge || isInRightEdge || isInTopEdge || isInBottomEdge)) {
+        cancelScrollAction();
+        return false;
+      }
+      
+      // If we made it this far, the user's mouse is located within the edge of the
+      // viewport. As such, we need to check to see if scrolling needs to be done.
+      
+      // Get the document dimensions.
+      // --
+      // NOTE: The various property reads here are for cross-browser compatibility
+      // as outlined in the JavaScript.info site (link provided above).
+      var documentWidth = Math.max(
+        container.scrollWidth,
+        container.offsetWidth,
+        container.clientWidth
+      );
+      var documentHeight = Math.max(
+        container.scrollHeight,
+        container.offsetHeight,
+        container.clientHeight
+      );
+      
+      // Calculate the maximum scroll offset in each direction. Since you can only
+      // scroll the overflow portion of the document, the maximum represents the
+      // length of the document that is NOT in the viewport.
+      var maxScrollX = (documentWidth - viewportWidth);
+      var maxScrollY = (documentHeight - viewportHeight);
+      
+      // As we examine the mousemove event, we want to adjust the window scroll in
+      // immediate response to the event; but, we also want to continue adjusting
+      // the window scroll if the user rests their mouse in the edge boundary. To
+      // do this, we'll invoke the adjustment logic immediately. Then, we'll setup
+      // a timer that continues to invoke the adjustment logic while the window can
+      // still be scrolled in a particular direction.
+      // --
+      // NOTE: There are probably better ways to handle the ongoing animation
+      // check. But, the point of this demo is really about the math logic, not so
+      // much about the interval logic.
+      (function checkForWindowScroll() {
+        cancelScrollAction();
+        
+        if (adjustWindowScroll()) {
+          timer = setTimeout( checkForWindowScroll, 30 );
+        }
+      })();
+      
+      // Adjust the window scroll based on the user's mouse position. Returns True
+      // or False depending on whether or not the window scroll was changed.
+      function adjustWindowScroll() {
+        // Get the current scroll position of the document.
+        var currentScrollX = container.scrollLeft;
+        var currentScrollY = container.scrollTop;
+        if (isBody) {
+          currentScrollX = window.pageXOffset;
+          currentScrollY = window.pageYOffset;
+        }
+        
+        // Determine if the window can be scrolled in any particular direction.
+        var canScrollUp = (currentScrollY > 0);
+        var canScrollDown = (currentScrollY < maxScrollY);
+        var canScrollLeft = (currentScrollX > 0);
+        var canScrollRight = (currentScrollX < maxScrollX);
+        
+        // Since we can potentially scroll in two directions at the same time,
+        // let's keep track of the next scroll, starting with the current scroll.
+        // Each of these values can then be adjusted independently in the logic
+        // below.
+        var nextScrollX = currentScrollX;
+        var nextScrollY = currentScrollY;
+        
+        // As we examine the mouse position within the edge, we want to make the
+        // incremental scroll changes more "intense" the closer that the user
+        // gets the viewport edge. As such, we'll calculate the percentage that
+        // the user has made it "through the edge" when calculating the delta.
+        // Then, that use that percentage to back-off from the "max" step value.
+        var maxStep = 50;
+        
+        // Should we scroll left?
+        if (isInLeftEdge && canScrollLeft) {
+          var intensity = ((edgeLeft - viewportX) / edgeSize);
+          nextScrollX = (nextScrollX - (maxStep * intensity));
+        }
+        // Should we scroll right?
+        else if (isInRightEdge && canScrollRight) {
+          var intensity = ((viewportX - edgeRight) / edgeSize);
+          nextScrollX = (nextScrollX + (maxStep * intensity));
+        }
+        
+        // Should we scroll up?
+        if (isInTopEdge && canScrollUp) {
+          var intensity = ((edgeTop - viewportY) / edgeSize);
+          nextScrollY = (nextScrollY - (maxStep * intensity));
+        }
+        // Should we scroll down?
+        else if (isInBottomEdge && canScrollDown) {
+          var intensity = ((viewportY - edgeBottom) / edgeSize);
+          nextScrollY = (nextScrollY + (maxStep * intensity));
+        }
+        
+        // Sanitize invalid maximums. An invalid scroll offset won't break the
+        // subsequent .scrollTo() call; however, it will make it harder to
+        // determine if the .scrollTo() method should have been called in the
+        // first place.
+        nextScrollX = Math.max(0, Math.min(maxScrollX, nextScrollX));
+        nextScrollY = Math.max(0, Math.min(maxScrollY, nextScrollY));
+        
+        if (
+          (nextScrollX !== currentScrollX) ||
+          (nextScrollY !== currentScrollY)
+        ) {
+          (isBody ? window : container).scrollTo(nextScrollX, nextScrollY);
+          return true;
+        }
+        else {
+          return false;
+        }
+      }
+      
+      return true
+    }
+
     var DragMixin = /** @class */ (function (_super) {
         __extends(DragMixin, _super);
         function DragMixin() {
@@ -327,6 +522,7 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
             var downEvent = null;
             var startPosition = null;
             var delayTimer = null;
+            var scrollContainer = null;
             var hasPassedDelay = true;
             el.addEventListener('mousedown', onMouseDown);
             el.addEventListener('touchstart', onMouseDown);
@@ -341,6 +537,12 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
             function noop(e) {
                 e.stopPropagation();
                 e.preventDefault();
+            }
+            function performVibration() {
+                // If browser can perform vibration and user has defined a vibration, perform it
+                if (comp.vibration > 0 && window.navigator && window.navigator.vibrate) {
+                    window.navigator.vibrate(comp.vibration);
+                }
             }
             function onMouseDown(e) {
                 var target;
@@ -357,6 +559,7 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
                 }
                 var goodTarget = !comp.handle || target.matches(comp.handle + ', ' + comp.handle + ' *');
                 if (!comp.disabled && downEvent === null && goodButton && goodTarget) {
+                    scrollContainer = scrollparent(target);
                     initialUserSelect = document.body.style.userSelect;
                     document.documentElement.style.userSelect = 'none'; // Permet au drag de se poursuivre normalement même
                     // quand on quitte un élémént avec overflow: hidden.
@@ -381,7 +584,11 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
                         clearTimeout(delayTimer);
                         delayTimer = setTimeout(function () {
                             hasPassedDelay = true;
+                            performVibration();
                         }, comp.delay);
+                    }
+                    else {
+                        performVibration();
                     }
                     document.addEventListener('click', onMouseClick, true);
                     document.addEventListener('mousemove', onMouseMove);
@@ -452,6 +659,9 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
                 }
                 // Dispatch custom easy-dnd-move event :
                 if (dragStarted) {
+                    // If cursor is at edge of container, perform scroll if available
+                    // If comp.dragTop is defined, it means they are dragging on top of another DropList/EasyDnd component
+                    performEdgeScroll(e, comp.dragTop ? scrollparent(comp.dragTop.$el) : scrollContainer, x, y);
                     var custom = new CustomEvent("easy-dnd-move", {
                         bubbles: true,
                         cancelable: true,
@@ -474,10 +684,12 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
             function onMouseUp(e) {
                 hasPassedDelay = true;
                 clearTimeout(delayTimer);
+                cancelScrollAction();
                 // On touch devices, we ignore fake mouse events and deal with touch events only.
                 if (downEvent.type === 'touchstart' && e.type === 'mouseup')
                     { return; }
                 downEvent = null;
+                scrollContainer = null;
                 // This delay makes sure that when the click event that results from the mouseup is produced, the drag is
                 // still in progress. So by checking the flag dnd.inProgress, one can tell apart true clicks from drag and
                 // drop artefacts.
@@ -597,6 +809,10 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
             vuePropertyDecorator.Prop({ type: String, default: null }),
             __metadata("design:type", String)
         ], DragMixin.prototype, "dragClass", void 0);
+        __decorate([
+            vuePropertyDecorator.Prop({ type: Number, default: 0 }),
+            __metadata("design:type", Number)
+        ], DragMixin.prototype, "vibration", void 0);
         DragMixin = __decorate([
             vuePropertyDecorator.Component({})
         ], DragMixin);
@@ -1751,6 +1967,10 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
             vuePropertyDecorator.Prop({ default: false, type: Boolean }),
             __metadata("design:type", Boolean)
         ], DropList.prototype, "noAnimations", void 0);
+        __decorate([
+            vuePropertyDecorator.Prop({ default: null, type: [String, Object] }),
+            __metadata("design:type", Object)
+        ], DropList.prototype, "defaultSlotClass", void 0);
         DropList = __decorate([
             vuePropertyDecorator.Component({
                 components: { DragFeedback: DragFeedback$1 },
@@ -1764,18 +1984,18 @@ var VueEasyDnD = (function (exports, reflectMetadata, vuePropertyDecorator) {
     var __vue_script__$4 = DropList;
 
     /* template */
-    var __vue_render__$4 = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c(_vm.rootTag,_vm._g(_vm._b({tag:"component",class:_vm.clazz,style:(_vm.style)},'component',_vm.rootProps,false),_vm.rootListeners),[(_vm.dropIn && _vm.dropAllowed)?[(_vm.reordering)?[(_vm.hasReorderingFeedback)?[_vm._l((_vm.itemsBeforeReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":index})}),_vm._v(" "),_vm._t("reordering-feedback",null,{"item":_vm.items[_vm.fromIndex]}),_vm._v(" "),_vm._l((_vm.itemsAfterReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":_vm.itemsBeforeReorderingFeedback.length + index})})]:[_vm._l((_vm.reorderedItems),function(item,index){return _vm._t("item",null,{"item":item,"index":index,"reorder":index === _vm.closestIndex})})]]:[_vm._l((_vm.itemsBeforeFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType}),_vm._v(" "),_vm._l((_vm.itemsAfterFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":_vm.itemsBeforeFeedback.length + index})})]]:[_vm._l((_vm.items),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),(_vm.items.length < 1)?_c('div',{key:"empty"},[_vm._t("empty")],2):_vm._e()],_vm._v(" "),(_vm.showDragFeedback)?_c('drag-feedback',{key:"drag-feedback",ref:"feedback",staticClass:"__feedback"},[_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType})],2):_vm._e(),_vm._v(" "),(_vm.showInsertingDragImage)?_c('div',{key:"inserting-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("drag-image",null,{"type":_vm.dragType,"data":_vm.dragData})],2):_vm._e(),_vm._v(" "),(_vm.showReorderingDragImage)?_c('div',{key:"reordering-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("reordering-drag-image",null,{"item":_vm.items[_vm.fromIndex]})],2):_vm._e(),_vm._v(" "),_c('div',{key:"drop-list-content"},[_vm._t("default")],2)],2)};
+    var __vue_render__$4 = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c(_vm.rootTag,_vm._g(_vm._b({tag:"component",class:_vm.clazz,style:(_vm.style)},'component',_vm.rootProps,false),_vm.rootListeners),[(_vm.dropIn && _vm.dropAllowed)?[(_vm.reordering)?[(_vm.hasReorderingFeedback)?[_vm._l((_vm.itemsBeforeReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":index})}),_vm._v(" "),_vm._t("reordering-feedback",null,{"item":_vm.items[_vm.fromIndex]}),_vm._v(" "),_vm._l((_vm.itemsAfterReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":_vm.itemsBeforeReorderingFeedback.length + index})})]:[_vm._l((_vm.reorderedItems),function(item,index){return _vm._t("item",null,{"item":item,"index":index,"reorder":index === _vm.closestIndex})})]]:[_vm._l((_vm.itemsBeforeFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType}),_vm._v(" "),_vm._l((_vm.itemsAfterFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":_vm.itemsBeforeFeedback.length + index})})]]:[_vm._l((_vm.items),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),(_vm.items.length < 1)?_c('div',{key:"empty",class:_vm.defaultSlotClass},[_vm._t("empty")],2):_vm._e()],_vm._v(" "),(_vm.showDragFeedback)?_c('drag-feedback',{key:"drag-feedback",ref:"feedback",staticClass:"__feedback"},[_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType})],2):_vm._e(),_vm._v(" "),(_vm.showInsertingDragImage)?_c('div',{key:"inserting-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("drag-image",null,{"type":_vm.dragType,"data":_vm.dragData})],2):_vm._e(),_vm._v(" "),(_vm.showReorderingDragImage)?_c('div',{key:"reordering-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("reordering-drag-image",null,{"item":_vm.items[_vm.fromIndex]})],2):_vm._e(),_vm._v(" "),_c('div',{key:"drop-list-content",class:_vm.defaultSlotClass},[_vm._t("default")],2)],2)};
     var __vue_staticRenderFns__$4 = [];
 
       /* style */
       var __vue_inject_styles__$4 = function (inject) {
         if (!inject) { return }
-        inject("data-v-b1058386_0", { source: ".drop-list[data-v-b1058386]>*{transition:transform .2s}.__feedback[data-v-b1058386]{display:none}.__drag-image[data-v-b1058386]{position:fixed;top:-10000px;left:-10000px;will-change:left,top}", map: undefined, media: undefined })
-    ,inject("data-v-b1058386_1", { source: ".drop-allowed.drop-in *{cursor:inherit!important}.drop-forbidden.drop-in,.drop-forbidden.drop-in *{cursor:no-drop!important}", map: undefined, media: undefined });
+        inject("data-v-0c0d6738_0", { source: ".drop-list[data-v-0c0d6738]>*{transition:transform .2s}.__feedback[data-v-0c0d6738]{display:none}.__drag-image[data-v-0c0d6738]{position:fixed;top:-10000px;left:-10000px;will-change:left,top}", map: undefined, media: undefined })
+    ,inject("data-v-0c0d6738_1", { source: ".drop-allowed.drop-in *{cursor:inherit!important}.drop-forbidden.drop-in,.drop-forbidden.drop-in *{cursor:no-drop!important}", map: undefined, media: undefined });
 
       };
       /* scoped */
-      var __vue_scope_id__$4 = "data-v-b1058386";
+      var __vue_scope_id__$4 = "data-v-0c0d6738";
       /* module identifier */
       var __vue_module_identifier__$4 = undefined;
       /* functional template */

--- a/lib/dist/vue-easy-dnd.ssr.js
+++ b/lib/dist/vue-easy-dnd.ssr.js
@@ -302,6 +302,201 @@ function copyStyle(src, destination) {
     destination.style.pointerEvents = 'none';
 }
 
+// Forked from https://gist.github.com/gre/296291b8ce0d8fe6e1c3ea4f1d1c5c3b
+var regex = /(auto|scroll)/;
+
+var style = function (node, prop) { return getComputedStyle(node, null).getPropertyValue(prop); };
+
+var scroll = function (node) { return regex.test(
+    style(node, "overflow") +
+    style(node, "overflow-y") +
+    style(node, "overflow-x")); };
+
+var scrollparent = function (node) { return !node || node===document.body
+    ? document.body
+    : scroll(node)
+      ? node
+      : scrollparent(node.parentNode); };
+
+// Forked from https://github.com/bennadel/JavaScript-Demos/blob/master/demos/window-edge-scrolling/index.htm
+// Code was altered to work with scrollable containers
+
+var edgeSize = 100;
+var timer = null;
+
+function cancelScrollAction () {
+  clearTimeout(timer);
+}
+
+function performEdgeScroll(event, container, clientX, clientY) {
+  if (!container) {
+    return false;
+  }
+  
+  // NOTE: Much of the information here, with regard to document dimensions,
+  // viewport dimensions, and window scrolling is derived from JavaScript.info.
+  // I am consuming it here primarily as NOTE TO SELF.
+  // --
+  // Read More: https://javascript.info/size-and-scroll-window
+  // --
+  // CAUTION: The viewport and document dimensions can all be CACHED and then
+  // recalculated on window-resize events (for the most part). I am keeping it
+  // all here in the mousemove event handler to remove as many of the moving
+  // parts as possible and keep the demo as simple as possible.
+  
+  // Get the viewport-relative coordinates of the mousemove event.
+  var rect = container.getBoundingClientRect();
+  var isBody = container === document.body;
+  
+  var viewportX = clientX - rect.left;
+  var viewportY = clientY - rect.top;
+  if (isBody) {
+    viewportX = clientX;
+    viewportY = clientY;
+  }
+  
+  // Get the viewport dimensions.
+  var viewportWidth = rect.width;
+  var viewportHeight = rect.height;
+  
+  // Next, we need to determine if the mouse is within the "edge" of the
+  // viewport, which may require scrolling the window. To do this, we need to
+  // calculate the boundaries of the edge in the viewport (these coordinates
+  // are relative to the viewport grid system).
+  var edgeTop = edgeSize;
+  var edgeLeft = edgeSize;
+  var edgeBottom = ( viewportHeight - edgeSize );
+  var edgeRight = ( viewportWidth - edgeSize );
+  
+  var isInLeftEdge = ( viewportX < edgeLeft );
+  var isInRightEdge = ( viewportX > edgeRight );
+  var isInTopEdge = ( viewportY < edgeTop );
+  var isInBottomEdge = ( viewportY > edgeBottom );
+  
+  // If the mouse is not in the viewport edge, there's no need to calculate
+  // anything else.
+  if (!(isInLeftEdge || isInRightEdge || isInTopEdge || isInBottomEdge)) {
+    cancelScrollAction();
+    return false;
+  }
+  
+  // If we made it this far, the user's mouse is located within the edge of the
+  // viewport. As such, we need to check to see if scrolling needs to be done.
+  
+  // Get the document dimensions.
+  // --
+  // NOTE: The various property reads here are for cross-browser compatibility
+  // as outlined in the JavaScript.info site (link provided above).
+  var documentWidth = Math.max(
+    container.scrollWidth,
+    container.offsetWidth,
+    container.clientWidth
+  );
+  var documentHeight = Math.max(
+    container.scrollHeight,
+    container.offsetHeight,
+    container.clientHeight
+  );
+  
+  // Calculate the maximum scroll offset in each direction. Since you can only
+  // scroll the overflow portion of the document, the maximum represents the
+  // length of the document that is NOT in the viewport.
+  var maxScrollX = (documentWidth - viewportWidth);
+  var maxScrollY = (documentHeight - viewportHeight);
+  
+  // As we examine the mousemove event, we want to adjust the window scroll in
+  // immediate response to the event; but, we also want to continue adjusting
+  // the window scroll if the user rests their mouse in the edge boundary. To
+  // do this, we'll invoke the adjustment logic immediately. Then, we'll setup
+  // a timer that continues to invoke the adjustment logic while the window can
+  // still be scrolled in a particular direction.
+  // --
+  // NOTE: There are probably better ways to handle the ongoing animation
+  // check. But, the point of this demo is really about the math logic, not so
+  // much about the interval logic.
+  (function checkForWindowScroll() {
+    cancelScrollAction();
+    
+    if (adjustWindowScroll()) {
+      timer = setTimeout( checkForWindowScroll, 30 );
+    }
+  })();
+  
+  // Adjust the window scroll based on the user's mouse position. Returns True
+  // or False depending on whether or not the window scroll was changed.
+  function adjustWindowScroll() {
+    // Get the current scroll position of the document.
+    var currentScrollX = container.scrollLeft;
+    var currentScrollY = container.scrollTop;
+    if (isBody) {
+      currentScrollX = window.pageXOffset;
+      currentScrollY = window.pageYOffset;
+    }
+    
+    // Determine if the window can be scrolled in any particular direction.
+    var canScrollUp = (currentScrollY > 0);
+    var canScrollDown = (currentScrollY < maxScrollY);
+    var canScrollLeft = (currentScrollX > 0);
+    var canScrollRight = (currentScrollX < maxScrollX);
+    
+    // Since we can potentially scroll in two directions at the same time,
+    // let's keep track of the next scroll, starting with the current scroll.
+    // Each of these values can then be adjusted independently in the logic
+    // below.
+    var nextScrollX = currentScrollX;
+    var nextScrollY = currentScrollY;
+    
+    // As we examine the mouse position within the edge, we want to make the
+    // incremental scroll changes more "intense" the closer that the user
+    // gets the viewport edge. As such, we'll calculate the percentage that
+    // the user has made it "through the edge" when calculating the delta.
+    // Then, that use that percentage to back-off from the "max" step value.
+    var maxStep = 50;
+    
+    // Should we scroll left?
+    if (isInLeftEdge && canScrollLeft) {
+      var intensity = ((edgeLeft - viewportX) / edgeSize);
+      nextScrollX = (nextScrollX - (maxStep * intensity));
+    }
+    // Should we scroll right?
+    else if (isInRightEdge && canScrollRight) {
+      var intensity = ((viewportX - edgeRight) / edgeSize);
+      nextScrollX = (nextScrollX + (maxStep * intensity));
+    }
+    
+    // Should we scroll up?
+    if (isInTopEdge && canScrollUp) {
+      var intensity = ((edgeTop - viewportY) / edgeSize);
+      nextScrollY = (nextScrollY - (maxStep * intensity));
+    }
+    // Should we scroll down?
+    else if (isInBottomEdge && canScrollDown) {
+      var intensity = ((viewportY - edgeBottom) / edgeSize);
+      nextScrollY = (nextScrollY + (maxStep * intensity));
+    }
+    
+    // Sanitize invalid maximums. An invalid scroll offset won't break the
+    // subsequent .scrollTo() call; however, it will make it harder to
+    // determine if the .scrollTo() method should have been called in the
+    // first place.
+    nextScrollX = Math.max(0, Math.min(maxScrollX, nextScrollX));
+    nextScrollY = Math.max(0, Math.min(maxScrollY, nextScrollY));
+    
+    if (
+      (nextScrollX !== currentScrollX) ||
+      (nextScrollY !== currentScrollY)
+    ) {
+      (isBody ? window : container).scrollTo(nextScrollX, nextScrollY);
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+  
+  return true
+}
+
 var DragMixin = /** @class */ (function (_super) {
     __extends(DragMixin, _super);
     function DragMixin() {
@@ -331,6 +526,7 @@ var DragMixin = /** @class */ (function (_super) {
         var downEvent = null;
         var startPosition = null;
         var delayTimer = null;
+        var scrollContainer = null;
         var hasPassedDelay = true;
         el.addEventListener('mousedown', onMouseDown);
         el.addEventListener('touchstart', onMouseDown);
@@ -345,6 +541,12 @@ var DragMixin = /** @class */ (function (_super) {
         function noop(e) {
             e.stopPropagation();
             e.preventDefault();
+        }
+        function performVibration() {
+            // If browser can perform vibration and user has defined a vibration, perform it
+            if (comp.vibration > 0 && window.navigator && window.navigator.vibrate) {
+                window.navigator.vibrate(comp.vibration);
+            }
         }
         function onMouseDown(e) {
             var target;
@@ -361,6 +563,7 @@ var DragMixin = /** @class */ (function (_super) {
             }
             var goodTarget = !comp.handle || target.matches(comp.handle + ', ' + comp.handle + ' *');
             if (!comp.disabled && downEvent === null && goodButton && goodTarget) {
+                scrollContainer = scrollparent(target);
                 initialUserSelect = document.body.style.userSelect;
                 document.documentElement.style.userSelect = 'none'; // Permet au drag de se poursuivre normalement même
                 // quand on quitte un élémént avec overflow: hidden.
@@ -385,7 +588,11 @@ var DragMixin = /** @class */ (function (_super) {
                     clearTimeout(delayTimer);
                     delayTimer = setTimeout(function () {
                         hasPassedDelay = true;
+                        performVibration();
                     }, comp.delay);
+                }
+                else {
+                    performVibration();
                 }
                 document.addEventListener('click', onMouseClick, true);
                 document.addEventListener('mousemove', onMouseMove);
@@ -456,6 +663,9 @@ var DragMixin = /** @class */ (function (_super) {
             }
             // Dispatch custom easy-dnd-move event :
             if (dragStarted) {
+                // If cursor is at edge of container, perform scroll if available
+                // If comp.dragTop is defined, it means they are dragging on top of another DropList/EasyDnd component
+                performEdgeScroll(e, comp.dragTop ? scrollparent(comp.dragTop.$el) : scrollContainer, x, y);
                 var custom = new CustomEvent("easy-dnd-move", {
                     bubbles: true,
                     cancelable: true,
@@ -478,10 +688,12 @@ var DragMixin = /** @class */ (function (_super) {
         function onMouseUp(e) {
             hasPassedDelay = true;
             clearTimeout(delayTimer);
+            cancelScrollAction();
             // On touch devices, we ignore fake mouse events and deal with touch events only.
             if (downEvent.type === 'touchstart' && e.type === 'mouseup')
                 { return; }
             downEvent = null;
+            scrollContainer = null;
             // This delay makes sure that when the click event that results from the mouseup is produced, the drag is
             // still in progress. So by checking the flag dnd.inProgress, one can tell apart true clicks from drag and
             // drop artefacts.
@@ -601,6 +813,10 @@ var DragMixin = /** @class */ (function (_super) {
         vuePropertyDecorator.Prop({ type: String, default: null }),
         __metadata("design:type", String)
     ], DragMixin.prototype, "dragClass", void 0);
+    __decorate([
+        vuePropertyDecorator.Prop({ type: Number, default: 0 }),
+        __metadata("design:type", Number)
+    ], DragMixin.prototype, "vibration", void 0);
     DragMixin = __decorate([
         vuePropertyDecorator.Component({})
     ], DragMixin);
@@ -1756,6 +1972,10 @@ var DropList = /** @class */ (function (_super) {
         vuePropertyDecorator.Prop({ default: false, type: Boolean }),
         __metadata("design:type", Boolean)
     ], DropList.prototype, "noAnimations", void 0);
+    __decorate([
+        vuePropertyDecorator.Prop({ default: null, type: [String, Object] }),
+        __metadata("design:type", Object)
+    ], DropList.prototype, "defaultSlotClass", void 0);
     DropList = __decorate([
         vuePropertyDecorator.Component({
             components: { DragFeedback: DragFeedback$1 },
@@ -1769,20 +1989,20 @@ var DropList = /** @class */ (function (_super) {
 var __vue_script__$4 = DropList;
 
 /* template */
-var __vue_render__$4 = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c(_vm.rootTag,_vm._g(_vm._b({tag:"component",class:_vm.clazz,style:(_vm.style)},'component',_vm.rootProps,false),_vm.rootListeners),[(_vm.dropIn && _vm.dropAllowed)?[(_vm.reordering)?[(_vm.hasReorderingFeedback)?[_vm._l((_vm.itemsBeforeReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":index})}),_vm._v(" "),_vm._t("reordering-feedback",null,{"item":_vm.items[_vm.fromIndex]}),_vm._v(" "),_vm._l((_vm.itemsAfterReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":_vm.itemsBeforeReorderingFeedback.length + index})})]:[_vm._l((_vm.reorderedItems),function(item,index){return _vm._t("item",null,{"item":item,"index":index,"reorder":index === _vm.closestIndex})})]]:[_vm._l((_vm.itemsBeforeFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType}),_vm._v(" "),_vm._l((_vm.itemsAfterFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":_vm.itemsBeforeFeedback.length + index})})]]:[_vm._l((_vm.items),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),(_vm.items.length < 1)?_c('div',{key:"empty"},[_vm._t("empty")],2):_vm._e()],_vm._v(" "),(_vm.showDragFeedback)?_c('drag-feedback',{key:"drag-feedback",ref:"feedback",staticClass:"__feedback"},[_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType})],2):_vm._e(),_vm._v(" "),(_vm.showInsertingDragImage)?_c('div',{key:"inserting-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("drag-image",null,{"type":_vm.dragType,"data":_vm.dragData})],2):_vm._e(),_vm._v(" "),(_vm.showReorderingDragImage)?_c('div',{key:"reordering-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("reordering-drag-image",null,{"item":_vm.items[_vm.fromIndex]})],2):_vm._e(),_vm._v(" "),_c('div',{key:"drop-list-content"},[_vm._t("default")],2)],2)};
+var __vue_render__$4 = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c(_vm.rootTag,_vm._g(_vm._b({tag:"component",class:_vm.clazz,style:(_vm.style)},'component',_vm.rootProps,false),_vm.rootListeners),[(_vm.dropIn && _vm.dropAllowed)?[(_vm.reordering)?[(_vm.hasReorderingFeedback)?[_vm._l((_vm.itemsBeforeReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":index})}),_vm._v(" "),_vm._t("reordering-feedback",null,{"item":_vm.items[_vm.fromIndex]}),_vm._v(" "),_vm._l((_vm.itemsAfterReorderingFeedback),function(item,index){return _vm._t("item",null,{"item":item,"index":_vm.itemsBeforeReorderingFeedback.length + index})})]:[_vm._l((_vm.reorderedItems),function(item,index){return _vm._t("item",null,{"item":item,"index":index,"reorder":index === _vm.closestIndex})})]]:[_vm._l((_vm.itemsBeforeFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType}),_vm._v(" "),_vm._l((_vm.itemsAfterFeedback),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":_vm.itemsBeforeFeedback.length + index})})]]:[_vm._l((_vm.items),function(item,index){return _vm._t("item",null,{"item":item,"reorder":false,"index":index})}),_vm._v(" "),(_vm.items.length < 1)?_c('div',{key:"empty",class:_vm.defaultSlotClass},[_vm._t("empty")],2):_vm._e()],_vm._v(" "),(_vm.showDragFeedback)?_c('drag-feedback',{key:"drag-feedback",ref:"feedback",staticClass:"__feedback"},[_vm._t("feedback",null,{"data":_vm.dragData,"type":_vm.dragType})],2):_vm._e(),_vm._v(" "),(_vm.showInsertingDragImage)?_c('div',{key:"inserting-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("drag-image",null,{"type":_vm.dragType,"data":_vm.dragData})],2):_vm._e(),_vm._v(" "),(_vm.showReorderingDragImage)?_c('div',{key:"reordering-drag-image",ref:"drag-image",staticClass:"__drag-image"},[_vm._t("reordering-drag-image",null,{"item":_vm.items[_vm.fromIndex]})],2):_vm._e(),_vm._v(" "),_c('div',{key:"drop-list-content",class:_vm.defaultSlotClass},[_vm._t("default")],2)],2)};
 var __vue_staticRenderFns__$4 = [];
 
   /* style */
   var __vue_inject_styles__$4 = function (inject) {
     if (!inject) { return }
-    inject("data-v-b1058386_0", { source: ".drop-list[data-v-b1058386]>*{transition:transform .2s}.__feedback[data-v-b1058386]{display:none}.__drag-image[data-v-b1058386]{position:fixed;top:-10000px;left:-10000px;will-change:left,top}", map: undefined, media: undefined })
-,inject("data-v-b1058386_1", { source: ".drop-allowed.drop-in *{cursor:inherit!important}.drop-forbidden.drop-in,.drop-forbidden.drop-in *{cursor:no-drop!important}", map: undefined, media: undefined });
+    inject("data-v-0c0d6738_0", { source: ".drop-list[data-v-0c0d6738]>*{transition:transform .2s}.__feedback[data-v-0c0d6738]{display:none}.__drag-image[data-v-0c0d6738]{position:fixed;top:-10000px;left:-10000px;will-change:left,top}", map: undefined, media: undefined })
+,inject("data-v-0c0d6738_1", { source: ".drop-allowed.drop-in *{cursor:inherit!important}.drop-forbidden.drop-in,.drop-forbidden.drop-in *{cursor:no-drop!important}", map: undefined, media: undefined });
 
   };
   /* scoped */
-  var __vue_scope_id__$4 = "data-v-b1058386";
+  var __vue_scope_id__$4 = "data-v-0c0d6738";
   /* module identifier */
-  var __vue_module_identifier__$4 = "data-v-b1058386";
+  var __vue_module_identifier__$4 = "data-v-0c0d6738";
   /* functional template */
   var __vue_is_functional_template__$4 = false;
 

--- a/lib/src/components/DropList.vue
+++ b/lib/src/components/DropList.vue
@@ -25,7 +25,7 @@
         </template>
         <template v-else>
             <slot name="item" v-for="(item, index) in items" :item="item" :reorder="false" :index="index"/>
-            <div key="empty" v-if="items.length < 1">
+            <div key="empty" v-if="items.length < 1" :class="defaultSlotClass">
               <slot name="empty" />
             </div>
         </template>
@@ -38,7 +38,7 @@
         <div class="__drag-image" v-if="showReorderingDragImage" ref="drag-image" key="reordering-drag-image">
             <slot name="reordering-drag-image" :item="items[fromIndex]"/>
         </div>
-        <div key="drop-list-content">
+        <div key="drop-list-content" :class="defaultSlotClass">
             <slot/>
         </div>
     </component>
@@ -73,6 +73,9 @@ export default class DropList extends DropMixin {
 
     @Prop({default: false, type: Boolean})
     noAnimations: boolean;
+
+    @Prop({default: null, type: [String, Object]})
+    defaultSlotClass;
 
     grid: Grid = null;
     forbiddenKeys = [];

--- a/lib/src/js/edgescroller.js
+++ b/lib/src/js/edgescroller.js
@@ -1,0 +1,178 @@
+// Forked from https://github.com/bennadel/JavaScript-Demos/blob/master/demos/window-edge-scrolling/index.htm
+// Code was altered to work with scrollable containers
+
+var edgeSize = 100;
+var timer = null;
+
+export function cancelScrollAction () {
+  clearTimeout(timer);
+}
+
+export function performEdgeScroll(event, container, clientX, clientY) {
+  if (!container) {
+    return false;
+  }
+  
+  // NOTE: Much of the information here, with regard to document dimensions,
+  // viewport dimensions, and window scrolling is derived from JavaScript.info.
+  // I am consuming it here primarily as NOTE TO SELF.
+  // --
+  // Read More: https://javascript.info/size-and-scroll-window
+  // --
+  // CAUTION: The viewport and document dimensions can all be CACHED and then
+  // recalculated on window-resize events (for the most part). I am keeping it
+  // all here in the mousemove event handler to remove as many of the moving
+  // parts as possible and keep the demo as simple as possible.
+  
+  // Get the viewport-relative coordinates of the mousemove event.
+  var rect = container.getBoundingClientRect();
+  var isBody = container === document.body;
+  
+  var viewportX = clientX - rect.left;
+  var viewportY = clientY - rect.top;
+  if (isBody) {
+    viewportX = clientX;
+    viewportY = clientY;
+  }
+  
+  // Get the viewport dimensions.
+  var viewportWidth = rect.width;
+  var viewportHeight = rect.height;
+  
+  // Next, we need to determine if the mouse is within the "edge" of the
+  // viewport, which may require scrolling the window. To do this, we need to
+  // calculate the boundaries of the edge in the viewport (these coordinates
+  // are relative to the viewport grid system).
+  var edgeTop = edgeSize;
+  var edgeLeft = edgeSize;
+  var edgeBottom = ( viewportHeight - edgeSize );
+  var edgeRight = ( viewportWidth - edgeSize );
+  
+  var isInLeftEdge = ( viewportX < edgeLeft );
+  var isInRightEdge = ( viewportX > edgeRight );
+  var isInTopEdge = ( viewportY < edgeTop );
+  var isInBottomEdge = ( viewportY > edgeBottom );
+  
+  // If the mouse is not in the viewport edge, there's no need to calculate
+  // anything else.
+  if (!(isInLeftEdge || isInRightEdge || isInTopEdge || isInBottomEdge)) {
+    cancelScrollAction();
+    return false;
+  }
+  
+  // If we made it this far, the user's mouse is located within the edge of the
+  // viewport. As such, we need to check to see if scrolling needs to be done.
+  
+  // Get the document dimensions.
+  // --
+  // NOTE: The various property reads here are for cross-browser compatibility
+  // as outlined in the JavaScript.info site (link provided above).
+  var documentWidth = Math.max(
+    container.scrollWidth,
+    container.offsetWidth,
+    container.clientWidth
+  );
+  var documentHeight = Math.max(
+    container.scrollHeight,
+    container.offsetHeight,
+    container.clientHeight
+  );
+  
+  // Calculate the maximum scroll offset in each direction. Since you can only
+  // scroll the overflow portion of the document, the maximum represents the
+  // length of the document that is NOT in the viewport.
+  var maxScrollX = (documentWidth - viewportWidth);
+  var maxScrollY = (documentHeight - viewportHeight);
+  
+  // As we examine the mousemove event, we want to adjust the window scroll in
+  // immediate response to the event; but, we also want to continue adjusting
+  // the window scroll if the user rests their mouse in the edge boundary. To
+  // do this, we'll invoke the adjustment logic immediately. Then, we'll setup
+  // a timer that continues to invoke the adjustment logic while the window can
+  // still be scrolled in a particular direction.
+  // --
+  // NOTE: There are probably better ways to handle the ongoing animation
+  // check. But, the point of this demo is really about the math logic, not so
+  // much about the interval logic.
+  (function checkForWindowScroll() {
+    cancelScrollAction()
+    
+    if (adjustWindowScroll()) {
+      timer = setTimeout( checkForWindowScroll, 30 );
+    }
+  })();
+  
+  // Adjust the window scroll based on the user's mouse position. Returns True
+  // or False depending on whether or not the window scroll was changed.
+  function adjustWindowScroll() {
+    // Get the current scroll position of the document.
+    var currentScrollX = container.scrollLeft;
+    var currentScrollY = container.scrollTop;
+    if (isBody) {
+      currentScrollX = window.pageXOffset;
+      currentScrollY = window.pageYOffset;
+    }
+    
+    // Determine if the window can be scrolled in any particular direction.
+    var canScrollUp = (currentScrollY > 0);
+    var canScrollDown = (currentScrollY < maxScrollY);
+    var canScrollLeft = (currentScrollX > 0);
+    var canScrollRight = (currentScrollX < maxScrollX);
+    
+    // Since we can potentially scroll in two directions at the same time,
+    // let's keep track of the next scroll, starting with the current scroll.
+    // Each of these values can then be adjusted independently in the logic
+    // below.
+    var nextScrollX = currentScrollX;
+    var nextScrollY = currentScrollY;
+    
+    // As we examine the mouse position within the edge, we want to make the
+    // incremental scroll changes more "intense" the closer that the user
+    // gets the viewport edge. As such, we'll calculate the percentage that
+    // the user has made it "through the edge" when calculating the delta.
+    // Then, that use that percentage to back-off from the "max" step value.
+    var maxStep = 50;
+    
+    // Should we scroll left?
+    if (isInLeftEdge && canScrollLeft) {
+      var intensity = ((edgeLeft - viewportX) / edgeSize);
+      nextScrollX = (nextScrollX - (maxStep * intensity));
+    }
+    // Should we scroll right?
+    else if (isInRightEdge && canScrollRight) {
+      var intensity = ((viewportX - edgeRight) / edgeSize);
+      nextScrollX = (nextScrollX + (maxStep * intensity));
+    }
+    
+    // Should we scroll up?
+    if (isInTopEdge && canScrollUp) {
+      var intensity = ((edgeTop - viewportY) / edgeSize);
+      nextScrollY = (nextScrollY - (maxStep * intensity));
+    }
+    // Should we scroll down?
+    else if (isInBottomEdge && canScrollDown) {
+      var intensity = ((viewportY - edgeBottom) / edgeSize);
+      nextScrollY = (nextScrollY + (maxStep * intensity));
+    }
+    
+    // Sanitize invalid maximums. An invalid scroll offset won't break the
+    // subsequent .scrollTo() call; however, it will make it harder to
+    // determine if the .scrollTo() method should have been called in the
+    // first place.
+    nextScrollX = Math.max(0, Math.min(maxScrollX, nextScrollX));
+    nextScrollY = Math.max(0, Math.min(maxScrollY, nextScrollY));
+    
+    if (
+      (nextScrollX !== currentScrollX) ||
+      (nextScrollY !== currentScrollY)
+    ) {
+      (isBody ? window : container).scrollTo(nextScrollX, nextScrollY);
+      return true;
+    }
+    else {
+      return false;
+    }
+  }
+  
+  return true
+}

--- a/lib/src/js/scrollparent.js
+++ b/lib/src/js/scrollparent.js
@@ -1,0 +1,20 @@
+// Forked from https://gist.github.com/gre/296291b8ce0d8fe6e1c3ea4f1d1c5c3b
+const regex = /(auto|scroll)/;
+
+const style = (node, prop) =>
+  getComputedStyle(node, null).getPropertyValue(prop);
+
+const scroll = (node) =>
+  regex.test(
+    style(node, "overflow") +
+    style(node, "overflow-y") +
+    style(node, "overflow-x"));
+
+const scrollparent = (node) =>
+  !node || node===document.body
+    ? document.body
+    : scroll(node)
+      ? node
+      : scrollparent(node.parentNode);
+
+export default scrollparent;

--- a/lib/src/mixins/DragMixin.ts
+++ b/lib/src/mixins/DragMixin.ts
@@ -214,7 +214,8 @@ export default class DragMixin extends DragAwareMixin {
             // Dispatch custom easy-dnd-move event :
             if (dragStarted) {
                 // If cursor is at edge of container, perform scroll if available
-                performEdgeScroll(e, scrollContainer, x, y);
+                // If comp.dragTop is defined, it means they are dragging on top of another DropList/EasyDnd component
+                performEdgeScroll(e, comp.dragTop ? scrollparent(comp.dragTop.$el) : scrollContainer, x, y);
 
                 let custom = new CustomEvent("easy-dnd-move", {
                     bubbles: true,

--- a/lib/src/mixins/DragMixin.ts
+++ b/lib/src/mixins/DragMixin.ts
@@ -37,6 +37,9 @@ export default class DragMixin extends DragAwareMixin {
     @Prop({type: String, default: null})
     dragClass: String;
 
+    @Prop({type: Number, default: 0})
+    vibration: number;
+
     mouseIn: boolean = null;
 
 
@@ -83,6 +86,13 @@ export default class DragMixin extends DragAwareMixin {
             e.preventDefault();
         }
 
+        function performVibration () {
+            // If browser can perform vibration and user has defined a vibration, perform it
+            if (comp.vibration > 0 && window.navigator && window.navigator.vibrate) {
+                window.navigator.vibrate(comp.vibration);
+            }
+        }
+
         function onMouseDown(e: MouseEvent | TouchEvent) {
             let target: HTMLElement;
             let goodButton: boolean;
@@ -122,7 +132,11 @@ export default class DragMixin extends DragAwareMixin {
                     clearTimeout(delayTimer);
                     delayTimer = setTimeout(() => {
                         hasPassedDelay = true;
+                        performVibration();
                     }, comp.delay);
+                }
+                else {
+                    performVibration();
                 }
 
                 document.addEventListener('click', onMouseClick, true);
@@ -199,7 +213,9 @@ export default class DragMixin extends DragAwareMixin {
 
             // Dispatch custom easy-dnd-move event :
             if (dragStarted) {
-                const isPerformingScroll = performEdgeScroll(e, scrollContainer, x, y);
+                // If cursor is at edge of container, perform scroll if available
+                performEdgeScroll(e, scrollContainer, x, y);
+
                 let custom = new CustomEvent("easy-dnd-move", {
                     bubbles: true,
                     cancelable: true,

--- a/src/App8.vue
+++ b/src/App8.vue
@@ -5,7 +5,7 @@
             <v-container fluid>
                 <v-row align-content="stretch">
                     <v-col>
-                      Hold down on items for 500ms before they will be draggable
+                      Hold down on items for 500ms before they will be draggable. Short tap vibration will happen on mobile
                         <v-list three-line class="list1">
                             <drop-list
                                 :items="items1"
@@ -14,7 +14,7 @@
                                 @insert="insert1"
                             >
                                 <template v-slot:item="{item, reorder, index}">
-                                    <drag :key="`item-${item}`" :data="item" @cut="remove(items1, item)" :delay="500">
+                                    <drag :key="`item-${item}`" :data="item" @cut="remove(items1, item)" :delay="500" :vibration="5">
                                         <v-list-item
                                             style="background-color: white; user-select: none"
                                             :style="reorder ? {borderLeft: '2px solid #1976D2', marginLeft:'-2px'} : {}"

--- a/src/App8.vue
+++ b/src/App8.vue
@@ -83,6 +83,52 @@
 
               </div>
             </v-container>
+
+            <div id="overlapper">
+              <drop-list
+                  :items="items1"
+                  mode="cut"
+                  @reorder="$event.apply(items1)"
+                  @insert="insert1"
+              >
+                <template v-slot:item="{item, reorder, index}">
+                  <drag :key="`item-${item}`" :data="item" @cut="remove(items1, item)" :delay="500" :vibration="5">
+                    <v-list-item
+                        style="background-color: white; user-select: none"
+                        :style="reorder ? {borderLeft: '2px solid #1976D2', marginLeft:'-2px'} : {}"
+                    >
+                      <v-list-item-avatar>
+                        {{ index }}
+                      </v-list-item-avatar>
+                      <v-list-item-content>
+                        <v-list-item-title v-html="item"/>
+                      </v-list-item-content>
+                    </v-list-item>
+                    <v-divider/>
+                  </drag>
+                </template>
+                <template v-slot:inserting-drag-image="{data}">
+                  <v-list-item-avatar style="transform:translate(-50%, -50%) scale(1.5)">
+                    <img :src="data"/>
+                  </v-list-item-avatar>
+                </template>
+                <template v-slot:reordering-drag-image/>
+                <template v-slot:feedback="{data}">
+                  <v-skeleton-loader
+                      type="list-item-avatar-three-line"
+                      :key="data"
+                      style="border-left: 2px solid #1976D2; margin-left: -2px;"
+                  />
+                </template>
+                <template v-slot:empty>
+                  <v-list-item>
+                    <v-list-item-content>
+                      No items to display in this list
+                    </v-list-item-content>
+                  </v-list-item>
+                </template>
+              </drop-list>
+            </div>
           </div>
         </v-content>
     </v-app>
@@ -178,7 +224,20 @@
       width: 85vw;
       margin: auto;
       overflow: auto;
-      position: absolute;
+      position: fixed;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
+    }
+
+    #overlapper {
+      background-color: lightblue;
+      height: 30vh;
+      width: 35vw;
+      margin: auto;
+      overflow: auto;
+      position: fixed;
       top: 0;
       bottom: 0;
       left: 0;

--- a/src/App8.vue
+++ b/src/App8.vue
@@ -1,6 +1,7 @@
 <template>
     <v-app>
         <v-content>
+          <div id="scroller">
             <v-container fluid>
                 <v-row align-content="stretch">
                     <v-col>
@@ -77,7 +78,12 @@
                         </drop-list>
                     </v-col>
                 </v-row>
+
+              <div ref="bottomRight" class="mouseovercontainer" @mouseenter="onMouseEnterBottomRight" @mouseleave="onMouseLeaveBottomRight">
+
+              </div>
             </v-container>
+          </div>
         </v-content>
     </v-app>
 </template>
@@ -117,6 +123,14 @@
             remove(array, value) {
                 let index = array.indexOf(value);
                 array.splice(index, 1);
+            },
+            onMouseEnterBottomRight () {
+              console.log('triggered enter')
+                this.$refs.bottomRight.style.background = 'green';
+            },
+            onMouseLeaveBottomRight () {
+              console.log('triggered leave')
+              this.$refs.bottomRight.style.background = 'purple';
             }
         }
     };
@@ -148,5 +162,26 @@
 
     .handle {
         cursor: grab;
+    }
+
+    .mouseovercontainer {
+      position: fixed;
+      bottom: 8px;
+      right: 8px;
+      width: 200px;
+      height: 200px;
+      background: purple;
+    }
+
+    #scroller {
+      height: 90vh;
+      width: 85vw;
+      margin: auto;
+      overflow: auto;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      left: 0;
+      right: 0;
     }
 </style>

--- a/src/App8.vue
+++ b/src/App8.vue
@@ -10,6 +10,7 @@
                             <drop-list
                                 :items="items1"
                                 mode="cut"
+                                default-slot-class="default-slot"
                                 @reorder="$event.apply(items1)"
                                 @insert="insert1"
                             >
@@ -208,6 +209,10 @@
 
     .handle {
         cursor: grab;
+    }
+
+    .default-slot {
+      background-color: lightpink;
     }
 
     .mouseovercontainer {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import 'regenerator-runtime/runtime'
 import 'custom-event-polyfill'
 import "reflect-metadata"
 import Vue from 'vue'
-import App from './App6.vue'
+import App from './App8.vue'
 import vuetify from './plugins/vuetify';
 import '@babel/polyfill'
 import 'roboto-fontface/css/roboto/roboto-fontface.css'


### PR DESCRIPTION
G'day again!

Got some further improvements:
- When dragging around the edge of a container, it will now automatically scroll left/right/up/down based on drag location. (Play around with src/App8.vue)
- Added tap vibration feedback on mobile browsers which support it (Drag prop `vibration`, default disabled)
- Added DropList prop `default-slot-class` which will bind classes to the outer div wrapping the `default` and `empty` slots. This somewhat solves https://github.com/rlemaigre/Easy-DnD/issues/36 as you can now add classes the outer div, however I could not efficiently remove this outer div without it breaking with transition-group or relying on keys.