### PR TITLE
DropList: Fixing default slot

### DIFF
--- a/lib/src/components/DropList.vue
+++ b/lib/src/components/DropList.vue
@@ -419,6 +419,18 @@ export default {
       ));
     }
 
+    if (this.$slots['default']) {
+      defaultArr.push(h(
+        'div',
+        {
+          class: '__default-content',
+          ref: 'default-content',
+          key: 'default-content'
+        },
+        this.$slots['default']()
+      ));
+    }
+
     return h(
       this.rootTag,
       {

--- a/src/App2.vue
+++ b/src/App2.vue
@@ -33,10 +33,15 @@
               {{ item }}
             </drag>
           </template>
+
           <template #feedback="{data}">
             <div :key="data" class="item feedback">
               {{ data }}
             </div>
+          </template>
+
+          <template #default>
+            Default
           </template>
         </drop-list>
       </div>


### PR DESCRIPTION
Hello everything is fine?

I'm opening this MR to fix a behavior where the default slot is not rendered at the end of the [drop-list](https://rlemaigre.github.io/Easy-DnD/components/droplist.html#slots).

I confess that I didn't stop much to test if everything is working fine after this correction.

Still can't see about adding the unit tests to help with that :(

But it would be interesting to add Vite + TS first, to have a better visibility in the development. What do you think?