### PR TITLE
fixed calc for drag image size

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vue-easy-dnd",
-  "version": "2.1.3",
+  "name": "@joebayld/vue-easy-dnd",
+  "version": "2.1.4",
   "description": "Easy-DnD is a drag and drop implementation for Vue 3 that uses only standard mouse events instead of the HTML5 drag and drop API, which is [impossible to work with](https://www.quirksmode.org/blog/archives/2009/09/the_html5_drag.html). Think of it as a way to transfer data from some components to others using the mouse or support for a mouse assisted copy/cut - paste. It also allows for lists to be reordred by drag and drop.",
   "main": "./dist/vue-easy-dnd.ssr.js",
   "module": "./dist/vue-easy-dnd.esm.js",
@@ -37,6 +37,11 @@
     "dnd"
   ],
   "author": "Régis Lemaigre <rlemaigre.github@gmail.com>",
+  "contributors": [
+    {
+      "name": "joebayld"
+    }
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/rlemaigre/Easy-DnD/issues"

--- a/lib/src/js/createDragImage.js
+++ b/lib/src/js/createDragImage.js
@@ -24,7 +24,7 @@ function deepClone (el) {
   copyStyle(el, clone);
   const vSrcElements = el.getElementsByTagName('*');
   const vDstElements = clone.getElementsByTagName('*');
-  for (let i = vSrcElements.length; i--;) {
+  for (let i = vSrcElements.length; i--; ) {
     const vSrcElement = vSrcElements[i];
     const vDstElement = vDstElements[i];
     copyStyle(vSrcElement, vDstElement);
@@ -40,20 +40,30 @@ function copyStyle (src, destination) {
   for (const key of computedStyle) {
     if (key === 'width') {
       // IE11
-      const width = computedStyle.getPropertyValue('box-sizing') === 'border-box' ?
-        src.clientWidth :
-        src.clientWidth - parseFloat(computedStyle.paddingLeft) - parseFloat(computedStyle.paddingRight);
+      const width =
+        computedStyle.getPropertyValue('box-sizing') === 'border-box'
+          ? src.getBoundingClientRect().width
+          : src.getBoundingClientRect().width -
+            parseFloat(computedStyle.paddingLeft) -
+            parseFloat(computedStyle.paddingRight);
       destination.style.setProperty('width', width + 'px');
     }
     else if (key === 'height') {
       // IE11
-      const height = computedStyle.getPropertyValue('box-sizing') === 'border-box' ?
-        src.clientHeight :
-        src.clientHeight - parseFloat(computedStyle.paddingTop) - parseFloat(computedStyle.paddingBottom);
+      const height =
+        computedStyle.getPropertyValue('box-sizing') === 'border-box'
+          ? src.getBoundingClientRect().height
+          : src.getBoundingClientRect().height -
+            parseFloat(computedStyle.paddingTop) -
+            parseFloat(computedStyle.paddingBottom);
       destination.style.setProperty('height', height + 'px');
     }
     else {
-      destination.style.setProperty(key, computedStyle.getPropertyValue(key), computedStyle.getPropertyPriority(key));
+      destination.style.setProperty(
+        key,
+        computedStyle.getPropertyValue(key),
+        computedStyle.getPropertyPriority(key)
+      );
     }
   }
   destination.style.pointerEvents = 'none';


### PR DESCRIPTION
I've come across issues where the styles are not correctly copied to the drag image. This occurred in specific svg shapes such as v-rect. Changing `clientWidth` and `clientHeight` to `getBoundingClientRect().width` and `getBoundingClientRect().height` seems to fix it. 