### PR TITLE
Copy canvas contents when creating a drag image

### DIFF
--- a/lib/src/js/createDragImage.js
+++ b/lib/src/js/createDragImage.js
@@ -22,12 +22,14 @@ export function createDragImage (el) {
 function deepClone (el) {
   const clone = el.cloneNode(true);
   copyStyle(el, clone);
+  copyCanvasContents(el, clone);
   const vSrcElements = el.getElementsByTagName('*');
   const vDstElements = clone.getElementsByTagName('*');
   for (let i = vSrcElements.length; i--;) {
     const vSrcElement = vSrcElements[i];
     const vDstElement = vDstElements[i];
     copyStyle(vSrcElement, vDstElement);
+    copyCanvasContents(vSrcElement, vDstElement);
   }
   return clone;
 }
@@ -45,4 +47,10 @@ function copyStyle (src, destination) {
     );
   }
   destination.style.pointerEvents = 'none';
+}
+
+function copyCanvasContents (src, destination) {
+  if (src.tagName === 'CANVAS' && destination.tagName === 'CANVAS') {
+    destination.getContext('2d').drawImage(src, 0, 0);
+  }
 }


### PR DESCRIPTION
As MDN documentation for `cloneNode` states (https://developer.mozilla.org/en-US/docs/Web/API/Node/cloneNode), if this method is used on a `canvas` element, the painted image is not copied. 

I am currently refactoring a Svelte app to use Vue and the library I used for Svelte handled that case. You can check their solution at https://github.com/isaacHagoel/svelte-dnd-action/blob/2d1190619d9259c7f5ffd858bd4bf8a2ad76e7ad/src/helpers/svelteNodeClone.js. I did the same for this library, only without explicit copying of width and height attributes, as those are copied by `cloneNode`.

Here's how it worked before:
[Screencast From 2025-06-16 17-21-18.webm](https://github.com/user-attachments/assets/3afea7bb-526c-48a4-82ee-a461bed549eb)

And here's how it works with changes from this PR:
[Screencast From 2025-06-16 17-22-04.webm](https://github.com/user-attachments/assets/fb911913-5f76-4412-8d87-e0d70a9e609f)